### PR TITLE
Do not use WorkflowMain Java class which does not exist anymore

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -51,7 +51,7 @@ if (params.datatype == 'yeast'){
 
 if (params.genome == 'GRCm38'){
     if(params.aligner == 'bwa'){
-        params.bwa_index = WorkflowMain.getGenomeAttribute(params, 'bwa')
+        params.bwa_index = getGenomeAttribute(params, 'bwa')
     }
 }
 


### PR DESCRIPTION
The old pipeline still used the WorkflowMain java class which is no longer included in the `lib/` directory. This PR references the directly imported function instead.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/callingcards/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/callingcards _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
