### PR TITLE
Archive nf-core/CallingCards project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# nf-core/CallingCards is now archived
+
+This project is no longer under active maintenance. You're welcome to use it, but no updates or bug fixes will be posted.
+
+If anyone is interested in taking over maintenance, please contact [Chase Mateusiak](https://github.com/cmatKhan)
+
 <h1>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/images/nf-core-callingcards_logo_dark.png">


### PR DESCRIPTION
Archive nf-core/callingcards

I did copy/paste the archive note from here:

https://github.com/ewels/clusterflow

in case it looks familiar